### PR TITLE
Update ScenarioDefs.xml

### DIFF
--- a/1.4/Defs/ScenarioDefs.xml
+++ b/1.4/Defs/ScenarioDefs.xml
@@ -84,7 +84,7 @@
 
                 <li Class="ScenPart_StartingThing_Defined" MayRequire="ceteam.combatextended">
                     <def>StartingThing_Defined</def>
-                    <thingDef>Ammo_Shotgungrim</thingDef>
+                    <thingDef>Ammo_10Gauge_Slug</thingDef>
                     <count>40</count>
                 </li>
 


### PR DESCRIPTION
We removed Ammo_Shotgrim in favor of using an already-made ammo from CE. This update removes it from spawning during the starting scenario and generates errors when the ammo files are removed.